### PR TITLE
Fix user programs require explicit `exit` syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,14 +160,14 @@ vectors.S: vectors.pl
 ULIB = ulib.o usys.o printf.o umalloc.o
 
 _%: %.o $(ULIB)
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(LD) $(LDFLAGS) -N -e _init -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
 
 _forktest: forktest.o $(ULIB)
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o _forktest forktest.o ulib.o usys.o
+	$(LD) $(LDFLAGS) -N -e _init -Ttext 0 -o _forktest forktest.o ulib.o usys.o
 	$(OBJDUMP) -S _forktest > forktest.asm
 
 mkfs: mkfs.c fs.h

--- a/forktest.c
+++ b/forktest.c
@@ -46,7 +46,7 @@ void forktest(void)      {
     printf(1, "fork test OK\n");
 }
 
-int main(void)     {
+int main(int argc, char* argv[])     {
     forktest();
     exit();
 }

--- a/init.c
+++ b/init.c
@@ -5,9 +5,9 @@
 #include "user.h"
 #include "fcntl.h"
 
-char *argv[] = { "sh", 0 };
+char *shell_argv[] = { "sh", 0 };
 
-int main(void) {
+int main(int argc, char* argv[]) {
     int pid, wpid;
 
     if (open("console", O_RDWR) < 0) {
@@ -25,7 +25,7 @@ int main(void) {
             exit();
         }
         if (pid == 0) {
-            exec("sh", argv);
+            exec("sh", shell_argv);
             printf(1, "init: exec sh failed\n");
             exit();
         }

--- a/sh.c
+++ b/sh.c
@@ -143,7 +143,7 @@ int getcmd(char *buf, int nbuf) {
     return 0;
 }
 
-int main(void) {
+int main(int argc, char* argv[]) {
     static char buf[100];
     int fd;
 

--- a/ulib.c
+++ b/ulib.c
@@ -96,3 +96,11 @@ void* memmove(void *vdst, const void *vsrc, int n) {
     }
     return vdst;
 }
+
+
+__attribute__((noreturn))
+int _init(int argc, char* argv[]) {
+	main(argc, argv);
+	exit();
+}
+

--- a/user.h
+++ b/user.h
@@ -38,3 +38,6 @@ void* memset(void*, int, uint);
 void* malloc(uint);
 void free(void*);
 int atoi(const char*);
+
+// entry-point
+extern int main(int, char*[]);

--- a/zombie.c
+++ b/zombie.c
@@ -5,7 +5,7 @@
 #include "stat.h"
 #include "user.h"
 
-int main(void)  {
+int main(int argc, char* argv[])  {
     if (fork() > 0) {
         sleep(5);  // Let child exit before parent.
     }


### PR DESCRIPTION
Resolves the issue where user programs need to explicitly call the `exit` system call before returning from `main` or else they will never exit.